### PR TITLE
Fix LaTeX math mode in adjustbox - wrap formula in $...$

### DIFF
--- a/backend/api/latex_utils.py
+++ b/backend/api/latex_utils.py
@@ -150,7 +150,7 @@ def build_latex_for_formulas(selected_formulas, columns=2, font_size="10pt", mar
             # Escape special LaTeX characters in the formula name
             escaped_name = name.replace("\\", "\\textbackslash ").replace("&", "\\&").replace("%", "\\%").replace("#", "\\#").replace("_", "\\_").replace("^", "\\textasciicircum ").replace("{", "\\{").replace("}", "\\}")
             body_lines.append("\\textbf{" + escaped_name + "}")
-            body_lines.append("\\[ \\adjustbox{max width=\\linewidth}{\\displaystyle " + latex + "} \\]")
+            body_lines.append("\\[ \\adjustbox{max width=\\linewidth}{$" + latex + "$} \\]")
             body_lines.append(f"\\\\[{formula_gap}]")
     
     if in_flushleft:

--- a/backend/api/latex_utils.py
+++ b/backend/api/latex_utils.py
@@ -150,7 +150,7 @@ def build_latex_for_formulas(selected_formulas, columns=2, font_size="10pt", mar
             # Escape special LaTeX characters in the formula name
             escaped_name = name.replace("\\", "\\textbackslash ").replace("&", "\\&").replace("%", "\\%").replace("#", "\\#").replace("_", "\\_").replace("^", "\\textasciicircum ").replace("{", "\\{").replace("}", "\\}")
             body_lines.append("\\textbf{" + escaped_name + "}")
-            body_lines.append("\\[ \\adjustbox{max width=\\linewidth}{$" + latex + "$} \\]")
+            body_lines.append("\\[ \\adjustbox{max width=\\linewidth}{$\\displaystyle " + latex + "$} \\]")
             body_lines.append(f"\\\\[{formula_gap}]")
     
     if in_flushleft:

--- a/backend/api/tests.py
+++ b/backend/api/tests.py
@@ -463,6 +463,23 @@ class TestGenerateSheetEndpoint:
         assert "\\documentclass[10pt,fleqn]{article}" in tex
         assert "extarticle" not in tex
 
+    def test_generate_sheet_formula_uses_displaystyle_in_adjustbox(self, api_client):
+        """Non-special-class formulas must be wrapped in $\\displaystyle ...$
+        inside \\adjustbox to preserve display-style math rendering."""
+        resp = api_client.post(
+            "/api/generate-sheet/",
+            {
+                "formulas": [
+                    {"class": "ALGEBRA I", "category": "Linear Equations", "name": "Slope Formula"}
+                ]
+            },
+            format="json",
+        )
+        assert resp.status_code == 200
+        tex = resp.json()["tex_code"]
+        assert "\\adjustbox{max width=\\linewidth}" in tex
+        assert "$\\displaystyle" in tex
+
     def test_generate_sheet_latex_injection_blocked(self, api_client):
         """LaTeX injection attempts in parameters should be sanitized."""
         resp = api_client.post(


### PR DESCRIPTION
This pull request makes a small change to the LaTeX rendering logic for formulas in the `build_latex_for_formulas` function. The main update is to ensure that formulas are wrapped in `$... math mode delimiters when rendered inside the `\adjustbox` command, which improves LaTeX formatting and compatibility.

LaTeX rendering improvement:

* Updated the formula rendering line in `build_latex_for_formulas` (in `latex_utils.py`) to wrap formulas with `$... inside `\adjustbox`, ensuring proper math mode handling.