### PR TITLE
Fix cheat sheet editor and saved-sheet state issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ A full-stack web application for generating LaTeX-based cheat sheets. Users sele
 | Frontend | React 18 + Vite |
 | Backend | Django 6 + Django REST Framework |
 | LaTeX Engine | Tectonic |
-| Database | SQLite (dev) / MariaDB (prod) |
+| Database | SQLite (dev) / PostgreSQL (Docker/prod) |
 | Container | Docker Compose |
 
 ## Project Structure
@@ -141,7 +141,7 @@ The frontend will be available at `http://localhost:5173/`.
 docker compose up --build
 ```
 
-This builds and starts the Django backend, React frontend, and MariaDB database.
+This builds and starts the Django backend, React frontend, and PostgreSQL database.
 
 ## Running Tests
 

--- a/backend/api/models.py
+++ b/backend/api/models.py
@@ -31,6 +31,44 @@ class CheatSheet(models.Model):
 
     def __str__(self):
         return self.title
+
+    def _build_practice_problems_section(self):
+        problems = list(self.problems.all())
+        if not problems:
+            return ""
+
+        section_lines = ["\\section*{Practice Problems}"]
+        for problem in problems:
+            section_lines.append(
+                f"\\textbf{{Problem {problem.order}:}} {problem.question_latex}"
+            )
+            if problem.answer_latex:
+                section_lines.append(f"\\textbf{{Answer:}} {problem.answer_latex}")
+            section_lines.append("")
+
+        return "\n".join(section_lines).rstrip()
+
+    def _inject_practice_problems_into_document(self, content):
+        practice_problems = self._build_practice_problems_section()
+        if not practice_problems:
+            return content
+
+        end_document = r"\end{document}"
+        end_multicols = r"\end{multicols}"
+
+        insert_before = end_document
+        if end_multicols in content and content.rfind(end_multicols) < content.rfind(end_document):
+            insert_before = end_multicols
+
+        insert_index = content.rfind(insert_before)
+        if insert_index == -1:
+            return content
+
+        return (
+            f"{content[:insert_index].rstrip()}\n\n"
+            f"{practice_problems}\n"
+            f"{content[insert_index:]}"
+        )
     
     def build_full_latex(self):
         """
@@ -40,13 +78,14 @@ class CheatSheet(models.Model):
         """
         content = self.latex_content or ""
         
-        # If it's already a complete document, return as-is
-        if r"\begin{document}" in content:
-            return content
+        # If it's already a complete document, keep its layout and inject problems if needed
+        if r"\begin{document}" in content and r"\end{document}" in content:
+            return self._inject_practice_problems_into_document(content)
             
         # Build document header
+        document_class = "extarticle" if self.font_size in {"8pt", "9pt"} else "article"
         header = [
-            "\\documentclass{article}",
+            f"\\documentclass{{{document_class}}}",
             "\\usepackage[utf8]{inputenc}",
             "\\usepackage{amsmath, amssymb}",
             f"\\usepackage[a4paper, margin={self.margins}]{{geometry}}",
@@ -54,7 +93,7 @@ class CheatSheet(models.Model):
         
         # Add font size if specified
         if self.font_size and self.font_size != "10pt":
-            header[0] = f"\\documentclass[{self.font_size}]{{article}}"
+            header[0] = f"\\documentclass[{self.font_size}]{{{document_class}}}"
             
         # Add multicolumn support if needed
         if self.columns > 1:
@@ -75,15 +114,9 @@ class CheatSheet(models.Model):
         # Add main content
         document_parts.append(content)
         
-        # Add practice problems if they exist
-        problems = self.problems.all()
-        if problems:
-            document_parts.append("\\section*{Practice Problems}")
-            for problem in problems:
-                document_parts.append(f"\\textbf{{Problem {problem.order}:}} {problem.question_latex}")
-                if problem.answer_latex:
-                    document_parts.append(f"\\textbf{{Answer:}} {problem.answer_latex}")
-                document_parts.append("")  # Add spacing
+        practice_problems = self._build_practice_problems_section()
+        if practice_problems:
+            document_parts.append(practice_problems)
         
         # Close multicolumn environment if needed
         if self.columns > 1:

--- a/backend/api/tests.py
+++ b/backend/api/tests.py
@@ -95,6 +95,50 @@ class TestCheatSheetModel(TestCase):
         )
         assert sheet.build_full_latex() == raw
 
+    def test_build_full_latex_passthrough_inserts_problems_before_document_end(self):
+        raw = "\\documentclass{article}\n\\begin{document}\nCustom\n\\end{document}"
+        sheet = CheatSheet.objects.create(
+            title="Raw With Problems",
+            latex_content=raw,
+        )
+        PracticeProblem.objects.create(
+            cheat_sheet=sheet,
+            question_latex="Show that $x^2 \\ge 0$.",
+            answer_latex="Because squares are nonnegative.",
+            order=1,
+        )
+
+        full = sheet.build_full_latex()
+
+        assert "Practice Problems" in full
+        assert "Show that $x^2 \\ge 0$." in full
+        assert full.index("Practice Problems") < full.index("\\end{document}")
+
+    def test_build_full_latex_passthrough_inserts_problems_before_end_multicols(self):
+        raw = (
+            "\\documentclass{article}\n"
+            "\\usepackage{multicol}\n"
+            "\\begin{document}\n"
+            "\\begin{multicols}{2}\n"
+            "Custom\n"
+            "\\end{multicols}\n"
+            "\\end{document}"
+        )
+        sheet = CheatSheet.objects.create(
+            title="Raw Multi",
+            latex_content=raw,
+        )
+        PracticeProblem.objects.create(
+            cheat_sheet=sheet,
+            question_latex="Integrate $x$.",
+            answer_latex="$x^2 / 2 + C$",
+            order=1,
+        )
+
+        full = sheet.build_full_latex()
+
+        assert full.index("Practice Problems") < full.index("\\end{multicols}")
+
     def test_build_full_latex_with_problems(self):
         sheet = CheatSheet.objects.create(
             title="With Problems",
@@ -110,6 +154,17 @@ class TestCheatSheetModel(TestCase):
         assert "Practice Problems" in full
         assert "What is $1+1$?" in full
         assert "$2$" in full
+
+    def test_build_full_latex_8pt_uses_extarticle(self):
+        sheet = CheatSheet.objects.create(
+            title="Small Font",
+            latex_content="Content",
+            font_size="8pt",
+        )
+
+        full = sheet.build_full_latex()
+
+        assert "\\documentclass[8pt]{extarticle}" in full
 
 
 # ── API Tests ────────────────────────────────────────────────────────

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -6,7 +6,7 @@ dj-database-url>=2.1
 psycopg2-binary>=2.9
 
 # Testing
-pytest>=8.0
+pytest>=9.0.3
 pytest-django>=4.8
 
 # Development (linting, security)

--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -3,6 +3,9 @@ import reactPlugin from 'eslint-plugin-react';
 import reactHooksPlugin from 'eslint-plugin-react-hooks';
 
 export default [
+  {
+    ignores: ['dist/**', 'node_modules/**'],
+  },
   js.configs.recommended,
   {
     files: ['**/*.{js,jsx}'],
@@ -39,6 +42,14 @@ export default [
     settings: {
       react: {
         version: 'detect'
+      }
+    }
+  },
+  {
+    files: ['vite.config.js'],
+    languageOptions: {
+      globals: {
+        process: 'readonly'
       }
     }
   }

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -23,7 +23,7 @@
         "eslint": "^9.0.0",
         "eslint-plugin-react": "^7.34.0",
         "eslint-plugin-react-hooks": "^5.0.0",
-        "vite": "^6.0.0"
+        "vite": "^6.4.2"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -4180,9 +4180,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5021,9 +5021,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "6.4.1",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.1.tgz",
-      "integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.2.tgz",
+      "integrity": "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -26,6 +26,9 @@
     "eslint": "^9.0.0",
     "eslint-plugin-react": "^7.34.0",
     "eslint-plugin-react-hooks": "^5.0.0",
-    "vite": "^6.0.0"
+    "vite": "^6.4.2"
+  },
+  "overrides": {
+    "picomatch": "^4.0.4"
   }
 }

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -16,6 +16,14 @@
   --input-bg: #0f0f12;
   --input-border: #3f3f46;
   --input-text: #fafafa;
+  --code-command: #7dd3fc;
+  --code-comment: #94a3b8;
+  --code-brace: #fbbf24;
+  --code-symbol: #c084fc;
+  --code-error: #fca5a5;
+  --code-error-bg: rgba(248, 113, 113, 0.12);
+  --code-error-gutter: rgba(248, 113, 113, 0.18);
+  --code-modified-bg: rgba(59, 130, 246, 0.08);
   
   /* Button colors */
   --btn-primary: #3b82f6;
@@ -64,6 +72,14 @@
   --input-bg: #ffffff;
   --input-border: #d4d4d8;
   --input-text: #18181b;
+  --code-command: #0369a1;
+  --code-comment: #64748b;
+  --code-brace: #b45309;
+  --code-symbol: #7c3aed;
+  --code-error: #b91c1c;
+  --code-error-bg: rgba(220, 38, 38, 0.1);
+  --code-error-gutter: rgba(220, 38, 38, 0.14);
+  --code-modified-bg: rgba(59, 130, 246, 0.08);
   
   --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.05);
   --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.08);
@@ -254,6 +270,7 @@ label {
 
 .editor-wrapper {
   display: flex;
+  position: relative;
   height: 60vh;
   max-height: 850px;
   min-height: 400px;
@@ -263,6 +280,11 @@ label {
   background-color: var(--input-bg);
   box-shadow: var(--shadow-inset);
   transition: border-color var(--transition-fast), box-shadow var(--transition-fast);
+}
+
+.editor-wrapper.has-error {
+  border-color: rgba(248, 113, 113, 0.45);
+  box-shadow: var(--shadow-inset), 0 0 0 1px rgba(248, 113, 113, 0.18);
 }
 
 .editor-wrapper:focus-within {
@@ -287,18 +309,86 @@ label {
   line-height: 1.6;
   color: var(--text-muted);
   height: calc(13px * 1.6);
+  padding-right: 2px;
 }
 
-.textarea-field {
+.line-number.error {
+  color: var(--code-error);
+  background: var(--code-error-gutter);
+  font-weight: 600;
+  border-radius: 4px;
+}
+
+.editor-surface {
+  position: relative;
   flex: 1;
+  overflow: hidden;
+}
+
+.editor-highlight-layer,
+.textarea-field {
+  position: absolute;
+  inset: 0;
   width: 100%;
   height: 100%;
   padding: var(--space-md);
   font-family: 'JetBrains Mono', 'Fira Code', 'Consolas', monospace;
   font-size: 13px;
   line-height: 1.6;
-  background-color: var(--input-bg);
+  white-space: pre;
+  tab-size: 2;
+  overflow: auto;
+}
+
+.editor-highlight-layer {
+  margin: 0;
   color: var(--input-text);
+  background: transparent;
+  pointer-events: none;
+  scrollbar-width: none;
+}
+
+.editor-highlight-layer::-webkit-scrollbar {
+  display: none;
+}
+
+.editor-highlight-layer.modified {
+  background: linear-gradient(180deg, var(--code-modified-bg) 0%, transparent 22%);
+}
+
+.editor-highlight-line {
+  min-height: calc(13px * 1.6);
+  color: var(--input-text);
+}
+
+.editor-highlight-line.error {
+  background: linear-gradient(90deg, var(--code-error-bg) 0%, transparent 85%);
+  border-left: 2px solid var(--code-error);
+  padding-left: calc(var(--space-sm) - 2px);
+}
+
+.latex-token.command {
+  color: var(--code-command);
+}
+
+.latex-token.comment {
+  color: var(--code-comment);
+}
+
+.latex-token.brace {
+  color: var(--code-brace);
+}
+
+.latex-token.symbol {
+  color: var(--code-symbol);
+}
+
+.textarea-field {
+  z-index: 1;
+  background-color: transparent;
+  color: transparent;
+  caret-color: var(--input-text);
+  -webkit-text-fill-color: transparent;
   border: none;
   border-radius: 0;
   resize: none;
@@ -306,13 +396,42 @@ label {
 }
 
 .textarea-field.modified {
-  color: #ffffff;
+  caret-color: var(--primary);
+}
+
+.textarea-field::selection {
+  background: rgba(59, 130, 246, 0.28);
+}
+
+.textarea-field::placeholder {
+  color: var(--text-muted);
+  -webkit-text-fill-color: var(--text-muted);
 }
 
 .textarea-field:focus {
   outline: none;
   border-color: var(--primary);
   box-shadow: var(--shadow-inset), 0 0 0 3px rgba(59, 130, 246, 0.1);
+}
+
+.editor-status {
+  margin-bottom: var(--space-sm);
+  padding: 0.5rem 0.75rem;
+  border-radius: var(--radius-sm);
+  font-size: 0.8125rem;
+  font-weight: 500;
+}
+
+.editor-status.modified {
+  color: var(--primary);
+  background: rgba(59, 130, 246, 0.08);
+  border: 1px solid rgba(59, 130, 246, 0.18);
+}
+
+.editor-status.error {
+  color: var(--code-error);
+  background: var(--code-error-bg);
+  border: 1px solid rgba(248, 113, 113, 0.24);
 }
 
 .layout-select {

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -2,6 +2,16 @@ import { useState, useEffect } from 'react'
 import './App.css'
 import CreateCheatSheet from './components/CreateCheatSheet';
 
+const DEFAULT_SHEET = {
+  title: '',
+  content: '',
+  columns: 2,
+  fontSize: '10pt',
+  spacing: 'large',
+  margins: '0.25in',
+  selectedFormulas: [],
+};
+
 function App() {
   const normalizeTheme = (value) => {
     return value === 'dark' || value === 'light' ? value : 'dark';
@@ -16,8 +26,9 @@ function App() {
         console.error("Failed to parse sheet", e);
       }
     }
-    return { title: '', content: '', columns: 2, fontSize: '10pt', spacing: 'large' };
+    return DEFAULT_SHEET;
   });
+  const [isSaving, setIsSaving] = useState(false);
   const [theme, setTheme] = useState(() => {
     const saved = localStorage.getItem('theme');
     return normalizeTheme(saved);
@@ -43,11 +54,61 @@ function App() {
     }
   }, []);
 
-  const handleSave = (data, showFeedback = true) => {
-    setCheatSheet(data);
-    localStorage.setItem('currentCheatSheet', JSON.stringify(data));
-    if (showFeedback) {
+  const handleSave = async (data, showFeedback = true) => {
+    const nextSheet = {
+      ...cheatSheet,
+      ...data,
+      selectedFormulas: data.selectedFormulas ?? cheatSheet.selectedFormulas ?? [],
+    };
+
+    setCheatSheet(nextSheet);
+    localStorage.setItem('currentCheatSheet', JSON.stringify(nextSheet));
+
+    if (!showFeedback) {
+      return nextSheet;
+    }
+
+    setIsSaving(true);
+
+    try {
+      const sheetId = nextSheet.id;
+      const response = await fetch(sheetId ? `/api/cheatsheets/${sheetId}/` : '/api/cheatsheets/', {
+        method: sheetId ? 'PATCH' : 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          title: nextSheet.title,
+          latex_content: nextSheet.content,
+          columns: nextSheet.columns,
+          margins: nextSheet.margins,
+          font_size: nextSheet.fontSize,
+          selected_formulas: nextSheet.selectedFormulas,
+        }),
+      });
+
+      if (!response.ok) {
+        const errorData = await response.json().catch(() => ({}));
+        throw new Error(errorData.detail || errorData.error || 'Failed to save cheat sheet');
+      }
+
+      const savedSheet = await response.json();
+      const persistedSheet = {
+        ...nextSheet,
+        id: savedSheet.id,
+        content: savedSheet.latex_content ?? nextSheet.content,
+        fontSize: savedSheet.font_size ?? nextSheet.fontSize,
+        selectedFormulas: savedSheet.selected_formulas ?? nextSheet.selectedFormulas,
+      };
+
+      setCheatSheet(persistedSheet);
+      localStorage.setItem('currentCheatSheet', JSON.stringify(persistedSheet));
       alert('Progress saved!');
+      return persistedSheet;
+    } catch (error) {
+      console.error('Failed to save cheat sheet', error);
+      alert(`Failed to save progress: ${error.message}`);
+      throw error;
+    } finally {
+      setIsSaving(false);
     }
   };
 
@@ -68,6 +129,7 @@ function App() {
         <CreateCheatSheet 
           initialData={cheatSheet} 
           onSave={handleSave} 
+          isSaving={isSaving}
           onCancel={() => {}} 
         />
       </main>

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -43,6 +43,11 @@ function App() {
     setTheme(prev => prev === 'dark' ? 'light' : 'dark');
   };
 
+  const handleReset = () => {
+    setCheatSheet(DEFAULT_SHEET);
+    localStorage.setItem('currentCheatSheet', JSON.stringify(DEFAULT_SHEET));
+  };
+
   useEffect(() => {
     const savedSheet = localStorage.getItem('currentCheatSheet');
     if (savedSheet) {
@@ -129,6 +134,7 @@ function App() {
         <CreateCheatSheet 
           initialData={cheatSheet} 
           onSave={handleSave} 
+          onReset={handleReset}
           isSaving={isSaving}
           onCancel={() => {}} 
         />

--- a/frontend/src/components/CreateCheatSheet.jsx
+++ b/frontend/src/components/CreateCheatSheet.jsx
@@ -581,7 +581,7 @@ const LayoutOptions = ({ columns, setColumns, fontSize, setFontSize, spacing, se
   </div>
 );
 
-const CreateCheatSheet = ({ onSave, initialData, isSaving = false }) => {
+const CreateCheatSheet = ({ onSave, onReset, initialData, isSaving = false }) => {
   const {
     classesData,
     selectedClasses,
@@ -655,7 +655,7 @@ const CreateCheatSheet = ({ onSave, initialData, isSaving = false }) => {
     if (window.confirm('Are you sure you want to clear everything? This cannot be undone.')) {
       clearLatex();
       clearSelections();
-      onSave({ title: '', content: '', columns: 2, fontSize: '10pt', spacing: 'large', margins: '0.25in' }, false);
+      onReset?.();
     }
   };
 

--- a/frontend/src/components/CreateCheatSheet.jsx
+++ b/frontend/src/components/CreateCheatSheet.jsx
@@ -368,14 +368,6 @@ const PdfPreview = ({ pdfBlob, compileError }) => {
     return () => resizeObserver.disconnect();
   }, []);
 
-  useEffect(() => {
-    fetch('/api/compile/', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ content: ' ' })
-    }).catch(e => console.log('Pre-warm compilation failed, ignoring:', e));
-  }, []);
-
   return (
     <div className="preview-section">
       <label>PDF Preview:</label>

--- a/frontend/src/components/CreateCheatSheet.jsx
+++ b/frontend/src/components/CreateCheatSheet.jsx
@@ -416,9 +416,9 @@ const PdfPreview = ({ pdfBlob, compileError }) => {
   );
 };
 
-const ActionToolbar = ({ handleDownloadTex, handleDownloadPDF, isLoading, content, handleClear }) => (
+const ActionToolbar = ({ handleDownloadTex, handleDownloadPDF, isLoading, isSaving, content, handleClear }) => (
   <div className="actions">
-    <button type="submit" className="btn primary">Save Progress</button>
+    <button type="submit" className="btn primary" disabled={isSaving}>{isSaving ? 'Saving...' : 'Save Progress'}</button>
     <button type="button" onClick={handleDownloadTex} className="btn download">Download .tex</button>
     <button
       type="button"
@@ -499,7 +499,7 @@ const LayoutOptions = ({ columns, setColumns, fontSize, setFontSize, spacing, se
   </div>
 );
 
-const CreateCheatSheet = ({ onSave, initialData }) => {
+const CreateCheatSheet = ({ onSave, initialData, isSaving = false }) => {
   const {
     classesData,
     selectedClasses,
@@ -515,7 +515,7 @@ const CreateCheatSheet = ({ onSave, initialData }) => {
     removeSingleFormula,
     selectedCount,
     hasSelectedClasses
-  } = useFormulas();
+  } = useFormulas(initialData);
 
   const {
     title,
@@ -556,9 +556,17 @@ const CreateCheatSheet = ({ onSave, initialData }) => {
     handleGenerateSheet(formulasList);
   };
 
-  const handleSave = (e) => {
+  const handleSave = async (e) => {
     e.preventDefault();
-    onSave({ title, content, columns, fontSize, spacing, margins });
+    await onSave({
+      title,
+      content,
+      columns,
+      fontSize,
+      spacing,
+      margins,
+      selectedFormulas: getSelectedFormulasList(),
+    });
   };
 
   const handleClear = () => {
@@ -664,6 +672,7 @@ const CreateCheatSheet = ({ onSave, initialData }) => {
           handleDownloadTex={handleDownloadTex}
           handleDownloadPDF={handleDownloadPDF}
           isLoading={isLoading}
+          isSaving={isSaving}
           content={content}
           handleClear={handleClear}
         />

--- a/frontend/src/components/CreateCheatSheet.jsx
+++ b/frontend/src/components/CreateCheatSheet.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef } from 'react';
+import React, { useState, useEffect, useRef, useMemo } from 'react';
 import { DndContext, closestCenter, KeyboardSensor, PointerSensor, useSensor, useSensors } from '@dnd-kit/core';
 import { SortableContext, sortableKeyboardCoordinates, verticalListSortingStrategy, useSortable } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
@@ -313,38 +313,128 @@ const FormulaSelection = ({
   </div>
 );
 
-const LatexEditor = ({ content, onChange, isModified }) => {
+const COMPILE_ERROR_LINE_REGEX = /document\.tex:(\d+):/g;
+
+const escapeHtml = (value = '') => value
+  .replace(/&/g, '&amp;')
+  .replace(/</g, '&lt;')
+  .replace(/>/g, '&gt;')
+  .replace(/"/g, '&quot;')
+  .replace(/'/g, '&#39;');
+
+const highlightLatexLine = (line = '') => {
+  const placeholders = [];
+  const stashToken = (html) => {
+    const placeholder = `LATEXTOKEN${placeholders.length}PLACEHOLDER`;
+    placeholders.push(html);
+    return placeholder;
+  };
+
+  let html = escapeHtml(line);
+
+  html = html.replace(/%.*$/g, (match) => stashToken(`<span class="latex-token comment">${match}</span>`));
+  html = html.replace(/\\[a-zA-Z@]+|\\./g, (match) => stashToken(`<span class="latex-token command">${match}</span>`));
+  html = html.replace(/[{}[\]]/g, (match) => `<span class="latex-token brace">${match}</span>`);
+  html = html.replace(/[$&#_^]/g, (match) => `<span class="latex-token symbol">${match}</span>`);
+
+  html = html.replace(/LATEXTOKEN(\d+)PLACEHOLDER/g, (_, index) => placeholders[Number(index)] ?? '');
+
+  return html || '&nbsp;';
+};
+
+const extractCompileErrorLines = (compileError = '') => {
+  const normalizedError = compileError || '';
+  const lineNumbers = new Set();
+
+  for (const match of normalizedError.matchAll(COMPILE_ERROR_LINE_REGEX)) {
+    lineNumbers.add(Number(match[1]));
+  }
+
+  return lineNumbers;
+};
+
+const getCompileErrorSummary = (compileError = '') => {
+  const normalizedError = compileError || '';
+
+  if (!normalizedError) {
+    return '';
+  }
+
+  const lineMatch = normalizedError.match(/document\.tex:(\d+):\s*([^\n]+)/);
+  if (lineMatch) {
+    return `Line ${lineMatch[1]}: ${lineMatch[2].replace(/^error:\s*/i, '').trim()}`;
+  }
+
+  return (normalizedError.split('\n').find((line) => line.trim()) || '').replace(/^error:\s*/i, '').trim();
+};
+
+const LatexEditor = ({ content, onChange, isModified, compileError }) => {
   const textareaRef = useRef(null);
   const lineNumbersRef = useRef(null);
+  const highlightLayerRef = useRef(null);
 
-  const lineCount = content ? content.split('\n').length : 1;
+  const errorLines = useMemo(() => extractCompileErrorLines(compileError), [compileError]);
+  const compileErrorSummary = useMemo(() => getCompileErrorSummary(compileError), [compileError]);
+  const highlightedLines = useMemo(() => {
+    const lines = content ? content.split('\n') : [''];
+
+    return lines.map((line, index) => ({
+      lineNumber: index + 1,
+      highlightedHtml: highlightLatexLine(line),
+      hasError: errorLines.has(index + 1),
+    }));
+  }, [content, errorLines]);
+
+  const lineCount = highlightedLines.length;
 
   const handleScroll = () => {
     if (lineNumbersRef.current && textareaRef.current) {
       lineNumbersRef.current.scrollTop = textareaRef.current.scrollTop;
+    }
+
+    if (highlightLayerRef.current && textareaRef.current) {
+      highlightLayerRef.current.scrollTop = textareaRef.current.scrollTop;
+      highlightLayerRef.current.scrollLeft = textareaRef.current.scrollLeft;
     }
   };
 
   return (
     <div className="input-section">
       <label htmlFor="content">Generated LaTeX Code:</label>
-      <div className="editor-wrapper">
+      {compileErrorSummary ? (
+        <div className="editor-status error">{compileErrorSummary}</div>
+      ) : isModified ? (
+        <div className="editor-status modified">Manual edits ready to recompile</div>
+      ) : null}
+      <div className={`editor-wrapper ${compileErrorSummary ? 'has-error' : ''}`}>
         <div className="line-numbers" ref={lineNumbersRef}>
           {Array.from({ length: lineCount }, (_, i) => (
-            <div key={i + 1} className="line-number">{i + 1}</div>
+            <div key={i + 1} className={`line-number ${errorLines.has(i + 1) ? 'error' : ''}`}>{i + 1}</div>
           ))}
         </div>
-        <textarea
-          ref={textareaRef}
-          id="content"
-          value={content}
-          onChange={(e) => onChange(e.target.value)}
-          onScroll={handleScroll}
-          placeholder='Select classes and categories above, then click "Generate Cheat Sheet" to see the LaTeX code here.'
-          className={`textarea-field ${isModified ? 'modified' : ''}`}
-          rows={15}
-          spellCheck="false"
-        />
+        <div className="editor-surface">
+          <div className={`editor-highlight-layer ${isModified ? 'modified' : ''}`} ref={highlightLayerRef} aria-hidden="true">
+            {highlightedLines.map(({ lineNumber, highlightedHtml, hasError }) => (
+              <div
+                key={lineNumber}
+                className={`editor-highlight-line ${hasError ? 'error' : ''}`}
+                dangerouslySetInnerHTML={{ __html: highlightedHtml }}
+              />
+            ))}
+          </div>
+          <textarea
+            ref={textareaRef}
+            id="content"
+            value={content}
+            onChange={(e) => onChange(e.target.value)}
+            onScroll={handleScroll}
+            placeholder='Select classes and categories above, then click "Generate Cheat Sheet" to see the LaTeX code here.'
+            className={`textarea-field ${isModified ? 'modified' : ''}`}
+            rows={15}
+            spellCheck="false"
+            wrap="off"
+          />
+        </div>
       </div>
     </div>
   );
@@ -387,7 +477,7 @@ const PdfPreview = ({ pdfBlob, compileError }) => {
             loading={<div style={{ padding: '2rem', color: '#666', textAlign: 'center' }}>Loading PDF...</div>}
             error={<div style={{ padding: '2rem', color: '#ff4444', textAlign: 'center' }}>Failed to load PDF.</div>}
           >
-            {Array.from(new Array(numPages), (el, index) => (
+            {Array.from(new Array(numPages), (_, index) => (
               <Page 
                 key={`page_${index + 1}`} 
                 pageNumber={index + 1} 
@@ -622,6 +712,7 @@ const CreateCheatSheet = ({ onSave, initialData, isSaving = false }) => {
             content={content}
             onChange={handleContentChange}
             isModified={contentModified}
+            compileError={compileError}
           />
           <div className="compile-button-column">
             <div className="history-buttons">
@@ -650,7 +741,7 @@ const CreateCheatSheet = ({ onSave, initialData, isSaving = false }) => {
               type="button"
               onClick={handleCompileClick}
               className="btn compile-circle"
-              disabled={isCompiling || !content}
+              disabled={isCompiling}
               title={isCompiling ? 'Compiling...' : 'Compile & Preview'}
               aria-label={isCompiling ? 'Compiling preview' : 'Compile and preview'}
             >

--- a/frontend/src/hooks/formulas.js
+++ b/frontend/src/hooks/formulas.js
@@ -58,6 +58,7 @@ export function useFormulas(initialData) {
   const [selectedCategories, setSelectedCategories] = useState({});
   const [groupedFormulas, setGroupedFormulas] = useState([]);
   const initialLoadDone = useRef(false);
+  const skipNextPersist = useRef(false);
 
   useEffect(() => {
     fetch('/api/classes/')
@@ -85,6 +86,13 @@ export function useFormulas(initialData) {
 
   useEffect(() => {
     if (!initialLoadDone.current) return;
+
+    if (skipNextPersist.current) {
+      skipNextPersist.current = false;
+      localStorage.removeItem(STORAGE_KEY);
+      return;
+    }
+
     saveToStorage({ selectedClasses, selectedCategories, groupedFormulas });
   }, [selectedClasses, selectedCategories, groupedFormulas]);
 
@@ -232,6 +240,7 @@ export function useFormulas(initialData) {
   const getSelectedFormulasList = () => groupedFormulas.flatMap(g => g.formulas);
 
   const clearSelections = () => {
+    skipNextPersist.current = true;
     setSelectedClasses({});
     setSelectedCategories({});
     setGroupedFormulas([]);

--- a/frontend/src/hooks/formulas.js
+++ b/frontend/src/hooks/formulas.js
@@ -22,7 +22,37 @@ function saveToStorage(data) {
   }
 }
 
-export function useFormulas() {
+function buildSelectionState(selectedFormulas = []) {
+  const groupedMap = new Map();
+  const selectedClasses = {};
+  const selectedCategories = {};
+
+  selectedFormulas.forEach((formula) => {
+    if (!formula?.class || !formula?.category || !formula?.name) return;
+
+    selectedClasses[formula.class] = true;
+    selectedCategories[`${formula.class}:${formula.category}`] = true;
+
+    const formulas = groupedMap.get(formula.class) || [];
+    formulas.push({
+      class: formula.class,
+      category: formula.category,
+      name: formula.name,
+    });
+    groupedMap.set(formula.class, formulas);
+  });
+
+  return {
+    selectedClasses,
+    selectedCategories,
+    groupedFormulas: Array.from(groupedMap.entries()).map(([className, formulas]) => ({
+      class: className,
+      formulas,
+    })),
+  };
+}
+
+export function useFormulas(initialData) {
   const [classesData, setClassesData] = useState([]);
   const [selectedClasses, setSelectedClasses] = useState({});
   const [selectedCategories, setSelectedCategories] = useState({});
@@ -42,11 +72,16 @@ export function useFormulas() {
             setSelectedClasses(saved.selectedClasses || {});
             setSelectedCategories(saved.selectedCategories || {});
             setGroupedFormulas(saved.groupedFormulas || []);
+          } else if (initialData?.selectedFormulas?.length) {
+            const restored = buildSelectionState(initialData.selectedFormulas);
+            setSelectedClasses(restored.selectedClasses);
+            setSelectedCategories(restored.selectedCategories);
+            setGroupedFormulas(restored.groupedFormulas);
           }
         }
       })
       .catch((err) => console.error('Failed to fetch classes', err));
-  }, []);
+  }, [initialData]);
 
   useEffect(() => {
     if (!initialLoadDone.current) return;

--- a/frontend/src/hooks/formulas.js
+++ b/frontend/src/hooks/formulas.js
@@ -114,11 +114,36 @@ export function useFormulas(initialData) {
     );
   }, []);
 
-  const removeClassFromOrder = useCallback((className) => {
-    setGroupedFormulas(prev => prev.filter(g => g.class !== className));
+  const clearClassSelections = useCallback((className) => {
+    setSelectedClasses((prev) => {
+      const updated = { ...prev };
+      delete updated[className];
+      return updated;
+    });
+
+    setSelectedCategories((prev) => {
+      const updated = { ...prev };
+      Object.keys(updated).forEach((key) => {
+        if (key.startsWith(`${className}:`)) {
+          delete updated[key];
+        }
+      });
+      return updated;
+    });
   }, []);
 
+  const removeClassFromOrder = useCallback((className) => {
+    clearClassSelections(className);
+    setGroupedFormulas(prev => prev.filter(g => g.class !== className));
+  }, [clearClassSelections]);
+
   const removeSingleFormula = useCallback((className, categoryName, formulaName) => {
+    setSelectedCategories((prev) => {
+      const updated = { ...prev };
+      delete updated[`${className}:${categoryName}`];
+      return updated;
+    });
+
     setGroupedFormulas(prev => prev.map(g => {
         if (g.class !== className) return g;
         return { ...g, formulas: g.formulas.filter(f => !(f.category === categoryName && f.name === formulaName)) };
@@ -140,7 +165,7 @@ export function useFormulas(initialData) {
           });
           return updatedCategories;
         });
-        removeClassFromOrder(className);
+        setGroupedFormulas((prevGrouped) => prevGrouped.filter((group) => group.class !== className));
       } else {
         newSelected[className] = true;
         const cls = classesData.find(c => c.name === className);

--- a/frontend/src/hooks/latex.js
+++ b/frontend/src/hooks/latex.js
@@ -301,10 +301,13 @@ export function useLatex(initialData) {
   const clearLatex = () => {
     setTitle('');
     setContent('');
+    setContentModified(false);
     setColumns(2);
     setFontSize('10pt');
     setSpacing('large');
     setMargins('0.25in');
+    setHistory([]);
+    setHistoryIndex(-1);
     if (pdfBlobUrlRef.current) {
       URL.revokeObjectURL(pdfBlobUrlRef.current);
       pdfBlobUrlRef.current = null;

--- a/frontend/src/hooks/latex.js
+++ b/frontend/src/hooks/latex.js
@@ -23,6 +23,15 @@ function saveLatexStorage(data) {
   }
 }
 
+function formatCompileError(errorData = {}) {
+  return (errorData.details || errorData.error || 'Failed to compile LaTeX')
+    .replace(/See the LaTeX manual or LaTeX Companion for explanation\.?/ig, '')
+    .replace(/Type\s+H <return>\s+for immediate help\.?/ig, '')
+    .replace(/error:\s*halted on potentially-recoverable error as specified\.?/ig, '')
+    .replace(/\n\s*\n/g, '\n')
+    .trim();
+}
+
 export function useLatex(initialData) {
   const [title, setTitle] = useState(initialData?.title ?? '');
   const [content, setContent] = useState(initialData?.content ?? '');
@@ -61,6 +70,8 @@ export function useLatex(initialData) {
       const newIndex = historyIndex - 1;
       setHistoryIndex(newIndex);
       setContent(history[newIndex]?.content || '');
+      setCompileError(null);
+      setContentModified(true);
     }
   }, [historyIndex, history]);
 
@@ -69,6 +80,8 @@ export function useLatex(initialData) {
       const newIndex = historyIndex + 1;
       setHistoryIndex(newIndex);
       setContent(history[newIndex]?.content || '');
+      setCompileError(null);
+      setContentModified(true);
     }
   }, [historyIndex, history]);
 
@@ -109,6 +122,7 @@ export function useLatex(initialData) {
 
   const handleContentChange = useCallback((newContent) => {
     setContent(newContent);
+    setCompileError(null);
     setContentModified(true);
   }, []);
 
@@ -124,104 +138,43 @@ export function useLatex(initialData) {
     };
   }, [title, content, columns, fontSize, spacing, margins]);
 
+  const compileLatexContent = useCallback(async (latexContent) => {
+    const response = await fetch('/api/compile/', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ content: latexContent }),
+    });
+
+    if (!response.ok) {
+      const errorData = await response.json().catch(() => ({}));
+      throw new Error(formatCompileError(errorData));
+    }
+
+    const blob = await response.blob();
+    if (pdfBlobUrlRef.current) {
+      URL.revokeObjectURL(pdfBlobUrlRef.current);
+    }
+    pdfBlobUrlRef.current = URL.createObjectURL(blob);
+    setPdfBlob(pdfBlobUrlRef.current);
+  }, []);
+
   const handleCompileOnly = useCallback(async () => {
     if (isCompilingRef.current) return;
-    if (!content) return;
     
     isCompilingRef.current = true;
     setIsCompiling(true);
     setCompileError(null);
-    
-    let contentToCompile = content;
-    
-    try {
-      const response = await fetch('/api/generate-sheet/', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          formulas: [],
-          columns: columns,
-          font_size: fontSize,
-          spacing: spacing,
-          margins: margins
-        }),
-      });
-      if (response.ok) {
-        const data = await response.json();
-        const newLatex = data.tex_code;
-        
-        const oldBodyMatch = content.match(/\\begin\{document\}([\s\S]*)\\end\{document\}/);
-        
-        if (oldBodyMatch) {
-          const oldBody = oldBodyMatch[1];
-          
-          const multicolMatch = oldBody.match(/\\begin\{multicols\}\{(\d+)\}([\s\S]*?)\\end\{multicols\}/);
-          
-          let formulaContent = oldBody;
-          if (multicolMatch) {
-            formulaContent = multicolMatch[2];
-          }
-          
-          const newParts = newLatex.split('\\begin{multicols}');
-          if (newParts.length > 1) {
-            const afterMulticols = newParts[1];
-            const columnMatch = afterMulticols.match(/^\{(\d+)\}/);
-            
-            if (columnMatch) {
-              const columnCount = columnMatch[1];
-              const afterColumn = afterMulticols.slice(columnMatch[0].length);
-              
-              const beforeEnd = afterColumn.split('\\end{multicols}')[0];
-              const afterEnd = afterColumn.split('\\end{multicols}').slice(1).join('\\end{multicols}');
-              
-              contentToCompile = newParts[0] + '\\begin{multicols}{' + columnCount + '}' + beforeEnd + formulaContent + '\\end{multicols}' + afterEnd;
-            } else {
-              contentToCompile = newLatex;
-            }
-          } else {
-            contentToCompile = newLatex;
-          }
-        } else {
-          contentToCompile = newLatex;
-        }
-      }
-    } catch (e) {
-      console.log('Regenerate failed, using existing content:', e);
-    }
-    
-    try {
-      const response = await fetch('/api/compile/', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ content: contentToCompile }),
-      });
-      if (!response.ok) {
-        const errorData = await response.json().catch(() => ({}));
-        let errorMsg = errorData.details || errorData.error || 'Failed to compile LaTeX';
-        
-        errorMsg = errorMsg
-          .replace(/See the LaTeX manual or LaTeX Companion for explanation\.?/ig, '')
-          .replace(/Type\s+H <return>\s+for immediate help\.?/ig, '')
-          .replace(/error:\s*halted on potentially-recoverable error as specified\.?/ig, '')
-          .replace(/\n\s*\n/g, '\n')
-          .trim();
 
-        throw new Error(errorMsg);
-      }
-      const blob = await response.blob();
-      if (pdfBlobUrlRef.current) {
-        URL.revokeObjectURL(pdfBlobUrlRef.current);
-      }
-      pdfBlobUrlRef.current = URL.createObjectURL(blob);
-      setPdfBlob(pdfBlobUrlRef.current);
+    try {
+      await compileLatexContent(content);
+      setContentModified(false);
     } catch (error) {
-      console.error('Error generating PDF:', error);
       setCompileError(error.message);
     } finally {
       setIsCompiling(false);
       isCompilingRef.current = false;
     }
-  }, [content, columns, fontSize, spacing, margins]);
+  }, [compileLatexContent, content]);
 
   const handlePreview = useCallback(async (latexContent = null, regenerateOptions = null) => {
     if (isCompilingRef.current) return;
@@ -252,44 +205,19 @@ export function useLatex(initialData) {
       }
     }
     
-    if (!contentToCompile) return;
-    
     isCompilingRef.current = true;
     setIsCompiling(true);
     setCompileError(null);
     try {
-      const response = await fetch('/api/compile/', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ content: contentToCompile }),
-      });
-      if (!response.ok) {
-        const errorData = await response.json().catch(() => ({}));
-        let errorMsg = errorData.details || errorData.error || 'Failed to compile LaTeX';
-        
-        errorMsg = errorMsg
-          .replace(/See the LaTeX manual or LaTeX Companion for explanation\.?/ig, '')
-          .replace(/Type\s+H <return>\s+for immediate help\.?/ig, '')
-          .replace(/error:\s*halted on potentially-recoverable error as specified\.?/ig, '')
-          .replace(/\n\s*\n/g, '\n')
-          .trim();
-
-        throw new Error(errorMsg);
-      }
-      const blob = await response.blob();
-      if (pdfBlobUrlRef.current) {
-        URL.revokeObjectURL(pdfBlobUrlRef.current);
-      }
-      pdfBlobUrlRef.current = URL.createObjectURL(blob);
-      setPdfBlob(pdfBlobUrlRef.current);
+      await compileLatexContent(contentToCompile);
+      setContentModified(false);
     } catch (error) {
-      console.error('Error generating PDF:', error);
       setCompileError(error.message);
     } finally {
       setIsCompiling(false);
       isCompilingRef.current = false;
     }
-  }, [content, margins, saveToHistory]);
+  }, [compileLatexContent, content, margins, saveToHistory]);
 
   const handleGenerateSheet = async (selectedList) => {
     if (isGeneratingRef.current) return;

--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -1,0 +1,11 @@
+{
+  "venvPath": "backend",
+  "venv": "venv",
+  "exclude": [
+    "**/node_modules",
+    "**/dist",
+    "backend/venv",
+    "backend/.pytest_cache",
+    "backend/.ruff_cache"
+  ]
+}


### PR DESCRIPTION
## Summary
- remove the invalid PDF prewarm request on page load and make the middle compile action always compile the exact LaTeX currently in the left editor
- add syntax-highlighted editor rendering plus compile-error line highlighting so failed LaTeX compiles stay visible and actionable in place
- fix clear/reset persistence so clearing a sheet also clears saved sheet identity, undo history, and stale formula storage across reloads
- keep formula checkbox state in sync after manual removals from the ordered list instead of dropping or restoring the wrong selections
- make saved-sheet full-document LaTeX passthrough inject practice problems correctly and use `extarticle` for wrapped 8pt/9pt documents

## Validation
- `npx eslint src`
- `npm run build`
- `python3 -m py_compile backend/api/models.py backend/api/tests.py`
- `"/tmp/cheat-sheet-verify-venv/bin/python" backend/manage.py test api.tests`
- live browser smoke test against local frontend/backend:
  - select `CALCULUS I` and generate a sheet
  - insert `\\badcommand` into the editor and confirm the error banner/highlighted line appear while the edited content stays intact
  - restore valid LaTeX and recompile successfully
  - clear the sheet, reload, and confirm `currentCheatSheet` is blank, `cheatSheetData` is removed, and no formulas remain selected

## Notes
- updated existing PR #50 for branch `bt/save-and-config-fixes`
- `AGENTS.md` was not changed, committed, or pushed