### PR TITLE
Draft: Polish LaTeX editor themes and video rail

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -643,6 +643,60 @@ label {
   color: var(--text-muted);
 }
 
+.latex-editor-heading-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: var(--space-sm);
+  margin-bottom: var(--space-sm);
+}
+
+.latex-editor-heading-row label {
+  margin-bottom: 0;
+}
+
+.latex-editor-theme-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.42rem;
+  min-height: 2rem;
+  padding: 0.34rem 0.62rem;
+  border: 1px solid color-mix(in srgb, var(--primary) 38%, var(--border) 62%);
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--card-bg) 88%, var(--primary) 12%);
+  color: var(--text);
+  font-size: 0.68rem;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+  cursor: pointer;
+  white-space: nowrap;
+  transition: transform var(--transition-fast), border-color var(--transition-fast), box-shadow var(--transition-fast), background var(--transition-fast);
+}
+
+.latex-editor-theme-toggle:hover {
+  border-color: var(--primary);
+  box-shadow: 0 8px 18px color-mix(in srgb, var(--primary) 16%, transparent 84%);
+  transform: translateY(-1px);
+}
+
+.latex-editor-theme-toggle:focus-visible {
+  outline: 2px solid color-mix(in srgb, var(--primary) 72%, white 28%);
+  outline-offset: 2px;
+}
+
+.theme-toggle-swatch {
+  width: 0.76rem;
+  height: 0.76rem;
+  border-radius: 999px;
+  background: linear-gradient(135deg, #7aa2f7 0%, #bb9af7 52%, #9ece6a 100%);
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--panel-bg) 86%, transparent 14%);
+}
+
+.latex-editor-theme-toggle-light .theme-toggle-swatch {
+  background: linear-gradient(135deg, #34548a 0%, #5a4a78 52%, #485e30 100%);
+}
+
 .latex-editor-loading {
   display: flex;
   align-items: center;
@@ -2530,7 +2584,9 @@ right panel - youtube resources
 */
 
 .right-panel {
-  background: color-mix(in srgb, var(--panel-bg) 94%, var(--bg) 6%);
+  background:
+    radial-gradient(circle at top left, color-mix(in srgb, var(--primary) 13%, transparent 87%), transparent 34%),
+    color-mix(in srgb, var(--panel-bg) 94%, var(--bg) 6%);
   border-left: 1px solid var(--border);
   display: flex;
   flex-direction: column;
@@ -2540,15 +2596,17 @@ right panel - youtube resources
 .right-panel-header {
   display: flex;
   align-items: center;
+  justify-content: space-between;
   gap: 0.45rem;
-  padding: 0.52rem 0.72rem;
-  font-weight: 600;
-  font-size: 0.62rem;
+  padding: 0.68rem 0.78rem;
+  font-weight: 800;
+  font-size: 0.68rem;
   text-transform: uppercase;
-  letter-spacing: 0.08em;
+  letter-spacing: 0.11em;
   border-bottom: 1px solid var(--border);
-  color: var(--text-muted);
+  color: var(--text);
   flex-shrink: 0;
+  background: color-mix(in srgb, var(--card-bg) 70%, transparent 30%);
 }
 
 .right-panel-scroll {
@@ -2556,7 +2614,7 @@ right panel - youtube resources
   overflow-y: auto;
   overflow-x: hidden;
   min-width: 0;
-  padding: 0.48rem 0.62rem 0.68rem;
+  padding: 0.68rem 0.66rem 0.78rem;
 }
 
 .right-panel-scroll::-webkit-scrollbar {
@@ -2625,19 +2683,22 @@ right panel - youtube resources
 
 .video-card-sm.compact {
   display: grid;
-  grid-template-columns: 84px minmax(0, 1fr);
+  grid-template-columns: 88px minmax(0, 1fr);
   align-items: center;
-  gap: 0.55rem;
-  padding: 0.35rem;
+  gap: 0.62rem;
+  padding: 0.42rem;
   text-align: left;
+  background:
+    linear-gradient(135deg, color-mix(in srgb, var(--card-bg) 92%, var(--primary) 8%) 0%, var(--card-bg) 100%);
 }
 
 .video-card-sm.compact .video-thumb-sm {
-  width: 84px;
-  min-width: 84px;
-  max-width: 84px;
+  width: 88px;
+  min-width: 88px;
+  max-width: 88px;
   aspect-ratio: 16 / 9;
-  border-radius: 10px;
+  border-radius: 12px;
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.08);
 }
 
 .video-card-sm.compact .video-thumb-sm img {
@@ -2668,8 +2729,8 @@ right panel - youtube resources
 
 .video-card-sm:hover {
   border-color: var(--primary);
-  box-shadow: none;
-  transform: translateY(-0.25px);
+  box-shadow: 0 10px 24px color-mix(in srgb, var(--primary) 13%, transparent 87%);
+  transform: translateY(-1px);
 }
 
 .video-card-sm:focus-visible {
@@ -2702,7 +2763,7 @@ right panel - youtube resources
   display: flex;
   align-items: center;
   justify-content: center;
-  background: rgba(0, 0, 0, 0.35);
+  background: radial-gradient(circle, rgba(122, 162, 247, 0.52), rgba(0, 0, 0, 0.45));
   color: white;
   font-size: 0.95rem;
   opacity: 0;
@@ -2711,6 +2772,14 @@ right panel - youtube resources
 
 .video-card-sm:hover .play-icon {
   opacity: 1;
+}
+
+.video-card-sm:hover .video-thumb-sm img {
+  transform: scale(1.04);
+}
+
+.video-thumb-sm img {
+  transition: transform var(--transition-fast);
 }
 
 .video-info-sm {
@@ -2740,7 +2809,7 @@ right panel - youtube resources
   -webkit-box-orient: vertical;
   overflow: hidden;
   font-size: 0.72rem;
-  font-weight: 500;
+  font-weight: 650;
   color: var(--text);
   line-height: 1.25;
   margin-bottom: 0.14rem;
@@ -2987,23 +3056,73 @@ three - column responsive
 }
 
 .subject-video-group{
-  margin-bottom: 0.44rem;
+  margin-bottom: 0.72rem;
   width: 100%;
   max-width: 100%;
   min-width: 0;
+  padding: 0.56rem;
+  border: 1px solid color-mix(in srgb, var(--border) 78%, var(--primary) 22%);
+  border-radius: 16px;
+  background: color-mix(in srgb, var(--card-bg) 82%, transparent 18%);
 }
 
 .subject-video-label {
-  display: block;
-  font-size: 0.66rem;
-  font-weight: 600;
-  letter-spacing: 0.01em;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.45rem;
+  font-size: 0.7rem;
+  font-weight: 800;
+  letter-spacing: 0.02em;
   color: var(--text);
   padding: 0 0.05rem;
-  margin-bottom: 0.18rem;
+  margin-bottom: 0.42rem;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+}
+
+.subject-video-label span {
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.subject-video-label small {
+  flex: 0 0 auto;
+  max-width: 45%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  color: var(--primary);
+  font-size: 0.54rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.section-video-picks {
+  position: relative;
+}
+
+.section-video-list,
+.section-video-results {
+  display: grid;
+  gap: 0.42rem;
+}
+
+.section-video-search-row {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.34rem;
+  margin-top: 0.38rem;
+}
+
+.section-video-search,
+.btn-clear-search,
+.video-more-toggle {
+  min-width: 2rem;
+  min-height: 2rem;
+  border-radius: 999px;
+  font-weight: 800;
 }
 
 .latex-fullscreen {

--- a/frontend/src/components/CreateCheatSheet.jsx
+++ b/frontend/src/components/CreateCheatSheet.jsx
@@ -31,7 +31,25 @@ const MIN_CENTER_WIDTH = 360;
 const MIN_PREVIEW_WIDTH = 260;
 const DEFAULT_PDF_ZOOM = 0.85;
 const MIN_SPLIT_CENTER_WIDTH = LATEX_PANEL_MIN_WIDTH + RESIZER_WIDTH + MIN_PREVIEW_WIDTH;
+const LATEX_EDITOR_THEME_STORAGE_KEY = 'latexEditorTheme';
+const LATEX_EDITOR_THEME_OPTIONS = [
+  { id: 'storm', label: 'Tokyo Night Storm' },
+  { id: 'night', label: 'Tokyo Night' },
+  { id: 'light', label: 'Tokyo Night Light' },
+];
+const DEFAULT_LATEX_EDITOR_THEME_ID = 'storm';
 const LatexCodeMirrorEditor = React.lazy(() => import('./LatexCodeMirrorEditor'));
+
+function loadLatexEditorTheme() {
+  try {
+    const savedTheme = localStorage.getItem(LATEX_EDITOR_THEME_STORAGE_KEY);
+    return LATEX_EDITOR_THEME_OPTIONS.some((theme) => theme.id === savedTheme)
+      ? savedTheme
+      : DEFAULT_LATEX_EDITOR_THEME_ID;
+  } catch {
+    return DEFAULT_LATEX_EDITOR_THEME_ID;
+  }
+}
 
 function loadPanelLayout() {
   try {
@@ -650,11 +668,13 @@ const getCompileErrorSummary = (compileError = '') => {
   return (normalizedError.split('\n').find((line) => line.trim()) || '').replace(/^error:\s*/i, '').trim();
 };
 
-const LatexEditor = ({ content, onChange, isModified, compileError }) => {
+const LatexEditor = ({ content, onChange, isModified, compileError, editorThemeId, onCycleEditorTheme }) => {
   const lastContentPropRef = useRef(content);
   const editorLabelId = useId();
   const [draftContent, setDraftContent] = useState(content);
   const compileErrorSummary = useMemo(() => getCompileErrorSummary(compileError), [compileError]);
+  const editorThemeLabel = LATEX_EDITOR_THEME_OPTIONS.find((theme) => theme.id === editorThemeId)?.label
+    || LATEX_EDITOR_THEME_OPTIONS[0].label;
 
   useEffect(() => {
     if (lastContentPropRef.current === content) return;
@@ -670,7 +690,19 @@ const LatexEditor = ({ content, onChange, isModified, compileError }) => {
 
   return (
     <div className="input-section">
-      <label id={editorLabelId}>Generated LaTeX Code:</label>
+      <div className="latex-editor-heading-row">
+        <label id={editorLabelId}>Generated LaTeX Code:</label>
+        <button
+          type="button"
+          className={`latex-editor-theme-toggle latex-editor-theme-toggle-${editorThemeId}`}
+          onClick={onCycleEditorTheme}
+          aria-label={`Editor theme: ${editorThemeLabel}`}
+          title={`Editor theme: ${editorThemeLabel}`}
+        >
+          <span className="theme-toggle-swatch" aria-hidden="true" />
+          <span>{editorThemeLabel}</span>
+        </button>
+      </div>
       {compileErrorSummary ? (
         <div className="editor-status error">{compileErrorSummary}</div>
       ) : isModified ? (
@@ -683,6 +715,7 @@ const LatexEditor = ({ content, onChange, isModified, compileError }) => {
               value={draftContent}
               isModified={isModified}
               labelId={editorLabelId}
+              editorThemeId={editorThemeId}
               onChange={handleEditorChange}
               placeholder='Select classes and categories above, then click "GET CHEAT SHEET" to see the LaTeX code here.'
             />
@@ -1100,6 +1133,7 @@ const CreateCheatSheet = ({ onSave, onReset, onRestoreSnapshot, initialData, isS
   const [rightPanelVisible, setRightPanelVisible] = useState(true);
   const [panelLayout, setPanelLayout] = useState(() => loadPanelLayout());
   const [videoSearchRequest, setVideoSearchRequest] = useState(null);
+  const [latexEditorThemeId, setLatexEditorThemeId] = useState(() => loadLatexEditorTheme());
   const [saveStatus, setSaveStatus] = useState('idle');
   const [lastSavedAt, setLastSavedAt] = useState(null);
   const [toast, setToast] = useState(null);
@@ -1131,6 +1165,18 @@ const CreateCheatSheet = ({ onSave, onReset, onRestoreSnapshot, initialData, isS
     () => selectedVideoTopics.map((topic) => `${topic.className}:${topic.category}`).join('|'),
     [selectedVideoTopics],
   );
+  const handleCycleLatexEditorTheme = useCallback(() => {
+    setLatexEditorThemeId((currentThemeId) => {
+      const currentIndex = LATEX_EDITOR_THEME_OPTIONS.findIndex((theme) => theme.id === currentThemeId);
+      const nextTheme = LATEX_EDITOR_THEME_OPTIONS[(currentIndex + 1) % LATEX_EDITOR_THEME_OPTIONS.length];
+      try {
+        localStorage.setItem(LATEX_EDITOR_THEME_STORAGE_KEY, nextTheme.id);
+      } catch {
+        // Theme switching should still work if localStorage is unavailable.
+      }
+      return nextTheme.id;
+    });
+  }, []);
   const curatedVideoResources = useMemo(
     () => getCuratedVideosForTopics(selectedVideoTopics),
     [selectedVideoTopics],
@@ -1765,6 +1811,8 @@ const CreateCheatSheet = ({ onSave, onReset, onRestoreSnapshot, initialData, isS
                        onChange={handleContentChange}
                        isModified={contentModified || hasLayoutChanges}
                        compileError={compileError}
+                       editorThemeId={latexEditorThemeId}
+                       onCycleEditorTheme={handleCycleLatexEditorTheme}
                      />
                    </div>
                    <button
@@ -1854,7 +1902,8 @@ const CreateCheatSheet = ({ onSave, onReset, onRestoreSnapshot, initialData, isS
                   return (
                     <div key={topicKey} className="subject-video-group">
                       <div className="subject-video-label" title={`${topic.className} · ${topic.category}`}>
-                        {topic.category}
+                        <span>{topic.category}</span>
+                        <small>{topic.className}</small>
                       </div>
                       <SectionVideoPicks
                         className={topic.className}

--- a/frontend/src/components/CreateCheatSheet.test.jsx
+++ b/frontend/src/components/CreateCheatSheet.test.jsx
@@ -414,6 +414,34 @@ describe('CreateCheatSheet Component', () => {
     expect(codeMirrorRenderSpy.mock.calls.at(-1)[0].basicSetup).toBe(initialBasicSetup);
   });
 
+  it('cycles and persists the LaTeX editor Tokyo Night theme without changing app theme', async () => {
+    useLatex.mockReturnValue({
+      ...mockUseLatex,
+      content: '\\frac{a}{b}',
+      pdfBlob: new Blob(['pdf'], { type: 'application/pdf' }),
+    });
+
+    render(<CreateCheatSheet onSave={vi.fn().mockResolvedValue(undefined)} onReset={vi.fn()} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /Show LaTeX editor/i }));
+
+    const themeButton = await screen.findByRole('button', { name: /Editor theme: Tokyo Night Storm/i });
+    expect(codeMirrorRenderSpy.mock.calls.at(-1)[0].className).toContain('latex-codemirror-theme-storm');
+    expect(document.documentElement.getAttribute('data-theme') || '').not.toMatch(/tokyo/i);
+
+    fireEvent.click(themeButton);
+
+    expect(screen.getByRole('button', { name: /Editor theme: Tokyo Night/i })).toBeInTheDocument();
+    expect(codeMirrorRenderSpy.mock.calls.at(-1)[0].className).toContain('latex-codemirror-theme-night');
+    expect(window.localStorage.getItem('latexEditorTheme')).toBe('night');
+
+    fireEvent.click(screen.getByRole('button', { name: /Editor theme: Tokyo Night/i }));
+
+    expect(screen.getByRole('button', { name: /Editor theme: Tokyo Night Light/i })).toBeInTheDocument();
+    expect(codeMirrorRenderSpy.mock.calls.at(-1)[0].className).toContain('latex-codemirror-theme-light');
+    expect(window.localStorage.getItem('latexEditorTheme')).toBe('light');
+  });
+
   it('updates CodeMirror when external LaTeX content changes', async () => {
     const { rerender } = render(
       <CreateCheatSheet onSave={vi.fn().mockResolvedValue(undefined)} onReset={vi.fn()} />

--- a/frontend/src/components/LatexCodeMirrorEditor.jsx
+++ b/frontend/src/components/LatexCodeMirrorEditor.jsx
@@ -5,46 +5,91 @@ import { EditorView } from '@codemirror/view';
 import { stex } from '@codemirror/legacy-modes/mode/stex';
 import { tags } from '@lezer/highlight';
 
-export const TOKYO_NIGHT_COLORS = {
-  background: '#1a1b26',
-  backgroundRaised: '#24283b',
-  foreground: '#c0caf5',
-  muted: '#565f89',
-  gutter: '#7aa2f7',
-  command: '#7aa2f7',
-  math: '#bb9af7',
-  symbol: '#89ddff',
-  string: '#9ece6a',
-  warning: '#e0af68',
-  selection: 'rgba(122, 162, 247, 0.28)',
-  activeLine: 'rgba(122, 162, 247, 0.08)',
+export const TOKYO_NIGHT_EDITOR_THEMES = {
+  storm: {
+    id: 'storm',
+    label: 'Tokyo Night Storm',
+    colors: {
+      background: '#1a1b26',
+      backgroundRaised: '#24283b',
+      foreground: '#c0caf5',
+      muted: '#565f89',
+      gutter: '#7aa2f7',
+      command: '#7aa2f7',
+      math: '#bb9af7',
+      symbol: '#89ddff',
+      string: '#9ece6a',
+      warning: '#e0af68',
+      selection: 'rgba(122, 162, 247, 0.28)',
+      activeLine: 'rgba(122, 162, 247, 0.08)',
+    },
+  },
+  night: {
+    id: 'night',
+    label: 'Tokyo Night',
+    colors: {
+      background: '#1a1b26',
+      backgroundRaised: '#16161e',
+      foreground: '#a9b1d6',
+      muted: '#565f89',
+      gutter: '#7aa2f7',
+      command: '#7aa2f7',
+      math: '#bb9af7',
+      symbol: '#89ddff',
+      string: '#9ece6a',
+      warning: '#ff9e64',
+      selection: 'rgba(111, 123, 182, 0.28)',
+      activeLine: 'rgba(41, 46, 66, 0.9)',
+    },
+  },
+  light: {
+    id: 'light',
+    label: 'Tokyo Night Light',
+    colors: {
+      background: '#d5d6db',
+      backgroundRaised: '#e1e2e7',
+      foreground: '#343b58',
+      muted: '#9699a3',
+      gutter: '#34548a',
+      command: '#34548a',
+      math: '#5a4a78',
+      symbol: '#166775',
+      string: '#485e30',
+      warning: '#965027',
+      selection: 'rgba(52, 84, 138, 0.18)',
+      activeLine: 'rgba(52, 84, 138, 0.08)',
+    },
+  },
 };
 
-const TOKYO_NIGHT_LATEX_HIGHLIGHT_STYLE = HighlightStyle.define([
-  { tag: [tags.keyword, tags.atom, tags.processingInstruction, tags.special(tags.variableName)], color: TOKYO_NIGHT_COLORS.command },
-  { tag: [tags.variableName, tags.typeName, tags.className, tags.definition(tags.variableName)], color: TOKYO_NIGHT_COLORS.foreground },
-  { tag: [tags.string, tags.regexp, tags.escape], color: TOKYO_NIGHT_COLORS.string },
-  { tag: [tags.number, tags.bool, tags.null], color: TOKYO_NIGHT_COLORS.warning },
-  { tag: [tags.operator, tags.compareOperator, tags.arithmeticOperator, tags.logicOperator], color: TOKYO_NIGHT_COLORS.symbol },
-  { tag: [tags.brace, tags.squareBracket, tags.paren, tags.punctuation, tags.separator], color: TOKYO_NIGHT_COLORS.symbol },
-  { tag: [tags.comment, tags.lineComment, tags.blockComment], color: TOKYO_NIGHT_COLORS.muted, fontStyle: 'italic' },
-  { tag: [tags.heading, tags.strong], color: TOKYO_NIGHT_COLORS.math },
-  { tag: [tags.link, tags.emphasis], color: TOKYO_NIGHT_COLORS.symbol },
+export const DEFAULT_TOKYO_NIGHT_EDITOR_THEME_ID = 'storm';
+
+export const TOKYO_NIGHT_EDITOR_THEME_ORDER = ['storm', 'night', 'light'];
+
+const LATEX_LANGUAGE_EXTENSION = StreamLanguage.define(stex);
+
+const createLatexHighlightStyle = (colors) => HighlightStyle.define([
+  { tag: [tags.keyword, tags.atom, tags.processingInstruction, tags.special(tags.variableName)], color: colors.command },
+  { tag: [tags.variableName, tags.typeName, tags.className, tags.definition(tags.variableName)], color: colors.foreground },
+  { tag: [tags.string, tags.regexp, tags.escape], color: colors.string },
+  { tag: [tags.number, tags.bool, tags.null], color: colors.warning },
+  { tag: [tags.operator, tags.compareOperator, tags.arithmeticOperator, tags.logicOperator], color: colors.symbol },
+  { tag: [tags.brace, tags.squareBracket, tags.paren, tags.punctuation, tags.separator], color: colors.symbol },
+  { tag: [tags.comment, tags.lineComment, tags.blockComment], color: colors.muted, fontStyle: 'italic' },
+  { tag: [tags.heading, tags.strong], color: colors.math },
+  { tag: [tags.link, tags.emphasis], color: colors.symbol },
 ]);
 
-const LATEX_LANGUAGE_EXTENSIONS = [
-  StreamLanguage.define(stex),
-  syntaxHighlighting(TOKYO_NIGHT_LATEX_HIGHLIGHT_STYLE),
-  EditorView.theme({
+const createEditorTheme = (colors) => EditorView.theme({
     '&': {
       height: '100%',
-      backgroundColor: TOKYO_NIGHT_COLORS.background,
-      color: TOKYO_NIGHT_COLORS.foreground,
+      backgroundColor: colors.background,
+      color: colors.foreground,
     },
     '.cm-editor': {
       height: '100%',
-      backgroundColor: TOKYO_NIGHT_COLORS.background,
-      color: TOKYO_NIGHT_COLORS.foreground,
+      backgroundColor: colors.background,
+      color: colors.foreground,
     },
     '.cm-scroller': {
       fontFamily: "'JetBrains Mono', 'Fira Code', 'Consolas', monospace",
@@ -52,7 +97,7 @@ const LATEX_LANGUAGE_EXTENSIONS = [
       lineHeight: '1.6',
     },
     '.cm-content': {
-      caretColor: TOKYO_NIGHT_COLORS.foreground,
+      caretColor: colors.foreground,
       padding: 'var(--space-md)',
       minHeight: '100%',
     },
@@ -60,28 +105,38 @@ const LATEX_LANGUAGE_EXTENSIONS = [
       padding: '0',
     },
     '.cm-gutters': {
-      backgroundColor: TOKYO_NIGHT_COLORS.backgroundRaised,
-      color: TOKYO_NIGHT_COLORS.muted,
-      borderRight: `1px solid ${TOKYO_NIGHT_COLORS.backgroundRaised}`,
+      backgroundColor: colors.backgroundRaised,
+      color: colors.muted,
+      borderRight: `1px solid ${colors.backgroundRaised}`,
     },
     '.cm-activeLineGutter': {
-      backgroundColor: TOKYO_NIGHT_COLORS.activeLine,
-      color: TOKYO_NIGHT_COLORS.gutter,
+      backgroundColor: colors.activeLine,
+      color: colors.gutter,
     },
     '.cm-activeLine': {
-      backgroundColor: TOKYO_NIGHT_COLORS.activeLine,
+      backgroundColor: colors.activeLine,
     },
     '.cm-selectionBackground, &.cm-focused .cm-selectionBackground': {
-      backgroundColor: TOKYO_NIGHT_COLORS.selection,
+      backgroundColor: colors.selection,
     },
     '.cm-placeholder': {
-      color: TOKYO_NIGHT_COLORS.muted,
+      color: colors.muted,
     },
     '&.cm-focused': {
       outline: 'none',
     },
-  }),
-];
+  });
+
+const LATEX_THEME_EXTENSION_CACHE = Object.fromEntries(
+  Object.entries(TOKYO_NIGHT_EDITOR_THEMES).map(([themeId, theme]) => [
+    themeId,
+    [
+      LATEX_LANGUAGE_EXTENSION,
+      syntaxHighlighting(createLatexHighlightStyle(theme.colors)),
+      createEditorTheme(theme.colors),
+    ],
+  ]),
+);
 
 const LATEX_BASIC_SETUP = {
   lineNumbers: true,
@@ -90,20 +145,30 @@ const LATEX_BASIC_SETUP = {
   highlightActiveLineGutter: true,
 };
 
-export default function LatexCodeMirrorEditor({ value, onChange, isModified, placeholder, labelId }) {
+export default function LatexCodeMirrorEditor({
+  value,
+  onChange,
+  isModified,
+  placeholder,
+  labelId,
+  editorThemeId = DEFAULT_TOKYO_NIGHT_EDITOR_THEME_ID,
+}) {
+  const resolvedThemeId = TOKYO_NIGHT_EDITOR_THEMES[editorThemeId]
+    ? editorThemeId
+    : DEFAULT_TOKYO_NIGHT_EDITOR_THEME_ID;
   const extensions = useMemo(() => [
-    ...LATEX_LANGUAGE_EXTENSIONS,
+    ...LATEX_THEME_EXTENSION_CACHE[resolvedThemeId],
     EditorView.contentAttributes.of({
       'aria-labelledby': labelId,
       spellcheck: 'false',
     }),
-  ], [labelId]);
+  ], [labelId, resolvedThemeId]);
 
   return (
     <CodeMirror
       value={value}
       height="100%"
-      className={`latex-codemirror ${isModified ? 'modified' : ''}`}
+      className={`latex-codemirror latex-codemirror-theme-${resolvedThemeId} ${isModified ? 'modified' : ''}`}
       basicSetup={LATEX_BASIC_SETUP}
       extensions={extensions}
       onChange={onChange}

--- a/frontend/src/components/LatexCodeMirrorEditor.test.jsx
+++ b/frontend/src/components/LatexCodeMirrorEditor.test.jsx
@@ -1,6 +1,6 @@
 import { render } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
-import LatexCodeMirrorEditor, { TOKYO_NIGHT_COLORS } from './LatexCodeMirrorEditor';
+import LatexCodeMirrorEditor, { TOKYO_NIGHT_EDITOR_THEMES } from './LatexCodeMirrorEditor';
 
 const { codeMirrorSpy } = vi.hoisted(() => ({
   codeMirrorSpy: vi.fn(),
@@ -14,7 +14,7 @@ vi.mock('@uiw/react-codemirror', () => ({
 }));
 
 describe('LatexCodeMirrorEditor', () => {
-  it('uses a mellow Tokyo Night palette for LaTeX editing', () => {
+  it('uses Tokyo Night Storm as the default LaTeX editor palette', () => {
     render(
       <LatexCodeMirrorEditor
         value="\\alpha"
@@ -25,7 +25,7 @@ describe('LatexCodeMirrorEditor', () => {
       />,
     );
 
-    expect(TOKYO_NIGHT_COLORS).toMatchObject({
+    expect(TOKYO_NIGHT_EDITOR_THEMES.storm.colors).toMatchObject({
       background: '#1a1b26',
       foreground: '#c0caf5',
       muted: '#565f89',
@@ -35,8 +35,32 @@ describe('LatexCodeMirrorEditor', () => {
       string: '#9ece6a',
     });
     expect(codeMirrorSpy).toHaveBeenCalledWith(expect.objectContaining({
-      className: 'latex-codemirror ',
+      className: 'latex-codemirror latex-codemirror-theme-storm ',
       extensions: expect.any(Array),
+    }));
+  });
+
+  it('can switch the LaTeX editor to Tokyo Night Light without changing app theme state', () => {
+    render(
+      <LatexCodeMirrorEditor
+        value="\\alpha"
+        onChange={vi.fn()}
+        isModified={false}
+        placeholder="Write LaTeX"
+        labelId="latex-editor-label"
+        editorThemeId="light"
+      />,
+    );
+
+    expect(TOKYO_NIGHT_EDITOR_THEMES.light.colors).toMatchObject({
+      background: '#d5d6db',
+      foreground: '#343b58',
+      command: '#34548a',
+      math: '#5a4a78',
+      string: '#485e30',
+    });
+    expect(codeMirrorSpy).toHaveBeenLastCalledWith(expect.objectContaining({
+      className: 'latex-codemirror latex-codemirror-theme-light ',
     }));
   });
 });


### PR DESCRIPTION
## Draft status

This PR is intentionally marked as a draft.

I opened it to preserve the work on this branch before the deadline. It is not meant to be merged yet, and I am treating the branch as frozen unless more changes are explicitly needed.

Please do not push additional changes to this branch. If more work is needed, it should happen in a follow-up branch or after confirming the next steps.

## Context

This branch started as a small UI polish pass, but the project had already moved forward from `main`. Main did not have the newer CodeMirror editor work yet; it was still on the older LaTeX editing experience.

Rather than trying to change too much at the last minute, I kept this branch focused on preserving the newer editor work and improving the parts that mattered most for the final PDF write-up. The goal was to avoid a risky redesign and keep the branch useful as a draft checkpoint.

## What changed

### CodeMirror LaTeX editor

- Added the newer CodeMirror-based LaTeX editor instead of relying on the older plain editor/overlay-style experience.
- Kept the LaTeX editor separate from the rest of the app theme so editor changes do not affect the whole UI.
- Added an editor-only Tokyo Night theme button.
- The editor defaults to Tokyo Night Storm.
- The theme button cycles through:
  - Tokyo Night Storm
  - Tokyo Night
  - Tokyo Night Light
- The selected editor theme is saved in `localStorage` under `latexEditorTheme`.

### Editor coloring and performance

- Split the editor colors into reusable Tokyo Night theme definitions.
- Cached the CodeMirror language, syntax highlighting, and theme extension sets by editor theme.
- This reduces repeated CodeMirror theme/highlighting setup during normal editor updates and should make scrolling and recoloring feel less laggy.

### Videos side rail

- Polished the right-side videos panel without changing the video data flow.
- Added clearer grouping for selected sections.
- Added class labels next to section names.
- Improved compact video cards with better spacing, thumbnails, hover states, and focus states.
- Kept the existing curated video and YouTube search behavior intact.

### Tests

- Added test coverage for cycling and persisting the LaTeX editor theme.
- Updated CodeMirror editor tests for the new Tokyo Night theme exports and theme-specific class names.

## Validation

Ran locally:

- `npm test -- --run`
- `npm run lint`
- `npm run build`

All passed locally.

## Notes

This is intentionally a draft PR. The branch captures the work done before the deadline, but I did not want to keep expanding scope when the priority was finishing the final PDF write-up.